### PR TITLE
Add yellowlab.tools check (fixes #63)

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ async function runChecks() {
   checks.ssllabs()
   checks.webbkoll()
   checks.webhint()
+  checks.yellowlab()
 }
 
 runChecks()

--- a/modules/checks.js
+++ b/modules/checks.js
@@ -10,6 +10,7 @@ const ssldecoder = require('./checks/ssldecoder')
 const ssllabs = require('./checks/ssllabs')
 const webbkoll = require('./checks/webbkoll')
 const webhint = require('./checks/webhint')
+const yellowlab = require('./checks/yellowlab')
 
 module.exports = {
     checkYourWebsite,
@@ -24,4 +25,5 @@ module.exports = {
     ssllabs,
     webbkoll,
     webhint,
+    yellowlab,
 }

--- a/modules/checks/yellowlab.js
+++ b/modules/checks/yellowlab.js
@@ -1,0 +1,24 @@
+const path = require('path')
+const checkFunction = require('../check-function')
+
+module.exports = async () => {
+  if (no_cli_flags || options_keys.includes('--yellowlab')) {
+    async function tryBlock(page) {
+      await page._client.send('Emulation.clearDeviceMetricsOverride')
+      await page.goto('https://yellowlab.tools/', { timeout: 240000, waitUntil: "domcontentloaded" })
+      await page.type(".url", url)
+      await page.click(".launchBtn")
+      await page.waitFor(".globalGrade", { timeout: 240000 })
+      await page.pdf({ path: path.resolve(output_path, './yellow-lab-1.pdf'), format: 'A4', printBackground: true })
+      await page.click("div.menuItem:nth-child(4)")
+      await page.waitFor(3000);
+      await page.pdf({ path: path.resolve(output_path, './yellow-lab-2.pdf'), format: 'A4', printBackground: true })
+    }
+    await checkFunction('Yellow Lab Tools', tryBlock)
+  }
+}
+
+module.exports.help = `
+  --yellowlab
+  Runs the Yellow Lab Tools check
+`

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:ssldecoder-fast": "node index.js iana.org --ssldecoder-fast",
     "test:ssllabs": "node index.js iana.org --ssllabs",
     "test:webbkoll": "node index.js iana.org --webbkoll",
-    "test:webhint": "node index.js iana.org --webhint"
+    "test:webhint": "node index.js iana.org --webhint",
+    "test:yellowlab": "node index.js iana.org --yellowlab"
   },
   "bin": {
     "website-checks": "./bin/website-checks.js"


### PR DESCRIPTION
This PR adds another check looking that analyses performance, as opposed to the many security checks. To test, one can run the command: `npm run test:yellowlab`. One should expect two files `yellow-lab-1.pdf` and `yellow-lab-2.pdf`, because the YellowLab check is captured from a two-page report.