### PR TITLE
Bump puppeteer to 5.3.1 and fix breaking changes (fixes #56)

### DIFF
--- a/modules/checks/check-your-website.js
+++ b/modules/checks/check-your-website.js
@@ -14,7 +14,7 @@ module.exports = async () => {
       await page.waitFor(10000)
       await page.waitForFunction('!document.querySelector(\'meta[http-equiv="refresh"]\')', { timeout: 340000 })
       await page.waitFor(1000)
-      await page.emulateMedia('screen')
+      await page.emulateMediaType('screen')
       await page.evaluate(() => document.querySelector('#sdCookieBanner').style.display = 'none')
       await page.pdf({ path: path.resolve(output_path, './check-your-website.pdf'), format: 'A4', printBackground: true })
     }

--- a/modules/checks/cryptcheck.js
+++ b/modules/checks/cryptcheck.js
@@ -11,7 +11,7 @@ module.exports = async () => {
       await page.waitForSelector('body > #flash + [class="container"]:not([id])', { timeout: 120000 })
       await page.waitForSelector('header')
       await page.evaluate(() => document.querySelector('header').style.display = 'none')
-      await page.emulateMedia('screen')
+      await page.emulateMediaType('screen')
       await page.pdf({ path: path.resolve(output_path, './cryptcheck.pdf'), format: 'A4', printBackground: true })
     }
     await checkFunction(name, tryBlock)

--- a/modules/checks/httpobservatory.js
+++ b/modules/checks/httpobservatory.js
@@ -8,7 +8,7 @@ module.exports = async () => {
       await page._client.send('Emulation.clearDeviceMetricsOverride')
       await page.goto('https://observatory.mozilla.org/analyze/' + url + '?third-party=false', { waitUntil: 'networkidle0' })
       await page.waitForSelector('#http-results', { timeout: 240000, visible: true })
-      await page.emulateMedia('screen')
+      await page.emulateMediaType('screen')
       await page.pdf({ path: path.resolve(output_path, './httpobservatory.pdf'), scale: 0.75, format: 'A4', printBackground: true })
     }
     await checkFunction(name, tryBlock)

--- a/modules/checks/ssldecoder.js
+++ b/modules/checks/ssldecoder.js
@@ -13,11 +13,11 @@ module.exports = async () => {
       if (linksLength) {
         for (let i = 0; i < linksLength; i++) {
           await page.goto(links[i], { timeout: 120000 })
-          await page.emulateMedia('screen')
+          await page.emulateMediaType('screen')
           await page.pdf({ path: path.resolve(output_path, './ssldecoder' + (fastcheck ? '-fast' : '') + '-' + (i + 1) + '.pdf'), format: 'A4', printBackground: true })
         }
       } else {
-        await page.emulateMedia('screen')
+        await page.emulateMediaType('screen')
         await page.pdf({ path: path.resolve(output_path, './ssldecoder' + (fastcheck ? '-fast' : '') + '.pdf'), format: 'A4', printBackground: true })
       }
     }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/website-checks/website-checks#readme",
   "dependencies": {
     "kleur": "4.0.2",
-    "puppeteer": "2.1.1"
+    "puppeteer": "5.3.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5"


### PR DESCRIPTION
This PR upgrades puppeteer to 5.3.1 and the breaking changes mentioned in 
#56 have been considered, therefore resolving the mentioned issue. Unlike any breaking changes, there however remains a new deprecation warning for the `waitFor` method, which hasn't been handled yet.