### PR TITLE
Rewrite psi check with xpaths instead of css selectors (fixes #84)

### DIFF
--- a/modules/checks/psi.js
+++ b/modules/checks/psi.js
@@ -2,18 +2,24 @@
 
 const path = require('path')
 const retry = require('../retry')
-const checkFunction = require('../check-function')
+const checkFunction = require('../check-function');
+const scrollToBottom = require('../../utils/scroll-to-bottom');
 
 module.exports = async () => {
   if (no_cli_flags || options_keys.includes('--psi')) {
     const name = 'PageSpeed Insights'
+    /** @param {import("puppeteer").Page} page */
     async function tryBlock(page) {
       await page._client.send('Emulation.clearDeviceMetricsOverride')
       await retry(() => page.goto('https://developers.google.com/speed/pagespeed/insights/?url=' + url + '&tab=mobile'), 1000)
-      await page.waitForSelector('#page-speed-insights .pagespeed-results .result-tabs', { timeout: 60000 })
-      await page.click('#page-speed-insights .pagespeed-results .result-tabs .goog-tab:nth-child(1)')
+      await page.waitForFunction(() => document.body.innerText.includes("Discover what your real users are experiencing"), { timeout: 600000 })
+      await (await page.$x('//span[contains(text(), "Ok, Got it.")]'))[0].click()
+      await scrollToBottom(page);
+      await page.waitForTimeout(3000)
       await page.pdf({ path: path.resolve(output_path, './psi-mobile.pdf'), format: 'A4', printBackground: true })
-      await page.click('#page-speed-insights .pagespeed-results .result-tabs .goog-tab:nth-child(2)')
+      await (await page.$x('//*[@id="desktop_tab"]/span[2]'))[0].click()
+      await scrollToBottom(page);
+      await page.waitForTimeout(3000)
       await page.pdf({ path: path.resolve(output_path, './psi-desktop.pdf'), format: 'A4', printBackground: true })
     }
     await checkFunction(name, tryBlock)

--- a/utils/scroll-to-bottom.js
+++ b/utils/scroll-to-bottom.js
@@ -1,0 +1,21 @@
+/**
+ * @param {import("puppeteer").Page} page 
+ */
+module.exports = async function (page) {
+    return page.evaluate(() => {
+        return new Promise(resolve => {
+            const scrollAmount = 100;
+            const scrollDelay = 500;
+            
+            function scroll() {
+                window.scrollBy({ top: scrollAmount });
+                if (window.scrollY < document.body.scrollHeight - document.body.clientHeight ) {
+                    setTimeout(scroll, scrollDelay);
+                } else {
+                    resolve();
+                }
+            }
+            scroll();
+        }) 
+    })
+}


### PR DESCRIPTION
This PR rewrites the PSI check, specifically the class based selectors into xpath, because PSI now obfusticates their classes. This also makes it harder to select tags, however with xpath, one can select tags with text inside them, avoiding the use of classes. 

This PR fixes the broken builds, however the quality of the PDF is poor. Only the core web vitals are visable. Suggested fix would be to include a auto scroll down function in `utils.js`, to trick the page into loading all components, thus the PDF will contain all parts.