### PR TITLE
Add --no-headless cmd option for debug purposes

### DIFF
--- a/modules/setup.js
+++ b/modules/setup.js
@@ -2,7 +2,7 @@
 
 module.exports =  async () => {
   return await puppeteer.launch({
-    headless: true, 
+    headless: !process.argv.includes("--no-headless"), 
     // slowMo: 1000,
     args: [
       '--lang=en', 


### PR DESCRIPTION
This PR adds a `--no-headless` command line option, useful for debugging. 